### PR TITLE
Add /r/mod/about/edited to preffeeds.html

### DIFF
--- a/r2/r2/templates/preffeeds.html
+++ b/r2/r2/templates/preffeeds.html
@@ -116,6 +116,9 @@ ${unsafe(safemarkdown(_("All feeds are invalidated if you change your password, 
       <%self:feedbuttons path="/r/mod/about/spam/"></%self:feedbuttons>
       ${_("spam")}
       <br/>
+      <%self:feedbuttons path="/r/mod/about/edited/"></%self:feedbuttons>
+      ${_("edited")}
+      <br/>
       <%self:feedbuttons path="/r/mod/about/log/"></%self:feedbuttons>
       ${_("moderation log")}
       <br/>


### PR DESCRIPTION
[Resolves this](https://www.reddit.com/r/bugs/comments/3pg4g8/the_edited_listing_is_missing_from_the_moderation/?ref=search_posts)

While this is being looked at it may be nice to add a plain /r/mod, /r/friends, /r/contrib "hot" listings up above. Maybe also the /me/f/all and whatever the urls are for the other filtered subreddit thing-a-mabobs.

Not sure that this works fully cause of [this](https://www.reddit.com/r/redditdev/comments/3qx925/prefsfeeds_fails_on_local_installs_gives_the/), but a test with viewing the `.json` urls in an incognito window and some other pages I mentioned make me think it should work.
